### PR TITLE
Display license info upon installation on win32 machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
         }
       ]
     },
+    "nsis": {
+      "license": "license.md"
+    },
     "snap": {
       "grade": "stable",
       "confinement": "strict"


### PR DESCRIPTION
## Description

Display the MIT license, as a dedicated step of the installation process, on x68/ia32 Win32 machines;

<p align="center">
  <img width="80%" src="https://user-images.githubusercontent.com/12670537/51412448-4c31d000-1b74-11e9-841b-56f6719f06f9.png">
</p>
