### PR TITLE
Include pacman as a build type for electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,10 @@
       "description": "Ao is an unofficial, featureful, open source, community-driven, free Microsoft To-Do app, used by people in more than 120 countries.",
       "synopsis": "Elegant Microsoft To-Do desktop app",
       "target": [
-         {
+        {
           "target": "pacman",
           "arch": [
+            "ia32",
             "x64"
           ]
         },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
       "description": "Ao is an unofficial, featureful, open source, community-driven, free Microsoft To-Do app, used by people in more than 120 countries.",
       "synopsis": "Elegant Microsoft To-Do desktop app",
       "target": [
+         {
+          "target": "pacman",
+          "arch": [
+            "x64"
+          ]
+        },
         {
           "target": "deb",
           "arch": [


### PR DESCRIPTION
This adds Pacman as an option to the electron build scripts.
Hopefully, it will be included in the Releases page.