### PR TITLE
Fix getPath error inside startup.js in macOS

### DIFF
--- a/src/startup.js
+++ b/src/startup.js
@@ -1,12 +1,12 @@
 'use strict';
-const {app} = require('electron');
+const {app, remote} = require('electron');
 const AutoLaunch = require('auto-launch');
 const {is} = require('./util');
 const settings = require('./settings');
 
 const _settings = {
   name: 'Ao',
-  path: is.darwin ? app.getPath('exe').replace(/\.app\/Content.*/, '.app') : undefined,
+  path: is.darwin ? (app || remote.app).getPath('exe').replace(/\.app\/Content.*/, '.app') : undefined,
   isHidden: true
 };
 


### PR DESCRIPTION
Fix the problem in #82 

There was an error `TypeError: Cannot read property 'getPath' of undefined` when I launched this app version 6.8.0 with macOS 10.14.4.

After fixed, now I can change a theme as intended.
![Screen Shot 2019-05-16 at 01 04 10](https://user-images.githubusercontent.com/3458544/57798264-91f35380-7776-11e9-8b66-cfcb9c1d942c.png)
