### PR TITLE
Add "CmdorCtrl+Q" shortcut to exit app.

### DIFF
--- a/src/configs/darwin.js
+++ b/src/configs/darwin.js
@@ -26,6 +26,7 @@ module.exports = {
     'toggle-black-mode': 'Cmd+B',
     'toggle-dark-mode': 'Cmd+H',
     'toggle-sepia-mode': 'Cmd+G',
-    'toggle-sidebar': 'Cmd+O'
+    'toggle-sidebar': 'Cmd+O',
+    'exit': 'Cmd+Q'
   }
 };

--- a/src/configs/linux.js
+++ b/src/configs/linux.js
@@ -26,6 +26,7 @@ module.exports = {
     'toggle-black-mode': 'Ctrl+B',
     'toggle-dark-mode': 'Ctrl+H',
     'toggle-sepia-mode': 'Ctrl+G',
-    'toggle-sidebar': 'Ctrl+O'
+    'toggle-sidebar': 'Ctrl+O',
+    'exit': 'Ctrl+Q'
   }
 };

--- a/src/configs/win32.js
+++ b/src/configs/win32.js
@@ -26,6 +26,7 @@ module.exports = {
     'toggle-black-mode': 'Ctrl+B',
     'toggle-dark-mode': 'Ctrl+H',
     'toggle-sepia-mode': 'Ctrl+G',
-    'toggle-sidebar': 'Ctrl+O'
+    'toggle-sidebar': 'Ctrl+O',
+    'exit': 'Ctrl+Q'
   }
 };

--- a/src/menu/app.js
+++ b/src/menu/app.js
@@ -1,11 +1,19 @@
 'use strict';
 const {app} = require('electron');
+const {setAcc} = require('./../keymap');
 const dialog = require('./../dialog');
 
 module.exports = {
   label: app.getName(),
   submenu: [
     {
+      role: 'about',
+      click() {
+        dialog.confirmAbout();
+      }
+    }, {
+      type: 'separator'
+    }, {
       role: 'services',
       submenu: []
     }, {
@@ -20,6 +28,7 @@ module.exports = {
       type: 'separator'
     }, {
       label: 'Exit',
+      accelerator: setAcc('exit', 'CmdorCtrl+Q'),
       click() {
         dialog.confirmExit();
       }

--- a/src/menu/help.js
+++ b/src/menu/help.js
@@ -111,13 +111,6 @@ module.exports = {
       click() {
         shell.openExternal(url.community);
       }
-    }, {
-      type: 'separator'
-    }, {
-      role: 'about',
-      click() {
-        dialog.confirmAbout();
-      }
     }
   ]
 };

--- a/src/startup.js
+++ b/src/startup.js
@@ -1,12 +1,12 @@
 'use strict';
-const {app} = require('electron');
+const {app, remote} = require('electron');
 const AutoLaunch = require('auto-launch');
 const {is} = require('./util');
 const settings = require('./settings');
 
 const _settings = {
   name: 'Ao',
-  path: is.darwin ? app.getPath('exe').replace(/\.app\/Content.*/, '.app') : undefined,
+  path: is.darwin ? (app || remote.app).getPath('exe').replace(/\.app\/Content.*/, '.app') : undefined,
   isHidden: true
 };
 


### PR DESCRIPTION
According to #62 and #81, the macOS shortcut to exit app doesn't exist in a previous version of Ao.
So I add the shortcut Cmd+q for macOS to exit an app, also add Ctrl+Q for other OS just in case.
I am also moving "about ao" dialogue to an app's menu.

![Screen Shot 2019-05-30 at 19 46 06](https://user-images.githubusercontent.com/3458544/58634582-d144a700-8315-11e9-8f46-4747d676ace8.png)
