### PR TITLE
Restore URL of update data endpoint

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -11,5 +11,5 @@ module.exports = {
   search: 'https://github.com/search?q=+is:issue+repo:klaussinani/ao',
   searchFeatureRequests: 'https://github.com/klaussinani/ao/labels/feature-request',
   source: 'https://github.com/klaussinani/ao',
-  update: 'https://klaussinani.github.io/ao/update.json'
+  update: 'https://raw.githubusercontent.com/klaussinani/ao/master/docs/update.json'
 };


### PR DESCRIPTION
## Description

The PR restores the URL used as the endpoint by the update checking API:

- Past URL: https://klaussinani.github.io/tusk/update.json
- New URL: https://raw.githubusercontent.com/klaussinani/tusk/master/docs/update.json