### PR TITLE
Fixes #80: Check if already shown on dom-ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ require('electron-dl')();
 require('electron-context-menu')();
 
 let exiting = false;
+let shown = false;
 let mainWindow;
 
 if (!app.requestSingleInstanceLock()) {
@@ -83,10 +84,13 @@ app.on('ready', () => {
     const stylesheets = fs.readdirSync(file.style);
     stylesheets.forEach(x => webContents.insertCSS(readSheet(x)));
 
-    if (settings.get('launchMinimized')) {
-      mainWindow.minimize();
-    } else {
-      mainWindow.show();
+    if(!shown) {
+      if (settings.get('launchMinimized')) {
+        mainWindow.minimize();
+      } else {
+        mainWindow.show();
+      }
+      shown = true;
     }
   });
 


### PR DESCRIPTION
Changing the callback on `webContents` for `dom-ready` to this:
```
webContents.on('dom-ready', () => {
    const stylesheets = fs.readdirSync(file.style);
    stylesheets.forEach(x => webContents.insertCSS(readSheet(x)));

   console.log("dom-ready");
    if (settings.get('launchMinimized')) {
      mainWindow.minimize();
    } else {
      mainWindow.show();
    }
  });
```
outputs the following on `npm start`:
```
> electron .

dom-ready
dom-ready
dom-ready
dom-ready
dom-ready
dom-ready
```
I believe repeated `dom-ready` fires was the reason for the window repeatedly stealing focus on startup. The window should now load in the background if clicked away from.

Using `ready-to-show` might also be an option, if the version of electron is updated:
https://github.com/electron/electron/issues/7779