### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/docs/i18n/readme.GER.md
+++ b/docs/i18n/readme.GER.md
@@ -66,7 +66,7 @@ Auf der [Github Releases](https://github.com/klaussinani/ao/releases/latest) Sei
 
 #### Homebrew
 
-Mit macOS und [`Homebrew Cask`](https://caskroom.github.io/) kannst du dir Ao über das Terminal installieren: `brew cask install ao`
+Mit macOS und [`Homebrew Cask`](https://caskroom.github.io/) kannst du dir Ao über das Terminal installieren: `brew install --cask ao`
 
 #### Snap
 

--- a/docs/i18n/readme.RUS.md
+++ b/docs/i18n/readme.RUS.md
@@ -70,7 +70,7 @@ Ao — это неофициальное и многофункционально
 
 ### Homebrew
 
-Пользователи macOS могут установить с помощью [`Homebrew Cask`](https://caskroom.github.io/) командой `brew cask install ao`.
+Пользователи macOS могут установить с помощью [`Homebrew Cask`](https://caskroom.github.io/) командой `brew install --cask ao`.
 
 ### Замечание
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Ubuntu Linux users can directly install through [`Snapcraft`](https://snapcraft.
 
 #### Homebrew
 
-Macos users can directly install through [`Homebrew Cask`](https://caskroom.github.io/) `brew cask install ao`
+Macos users can directly install through [`Homebrew Cask`](https://caskroom.github.io/) `brew install --cask ao`
 
 #### Note
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103257562-0541eb80-49d5-11eb-9cb8-3b2e77ed6e3c.png)


<!--

Thank you for taking the time to contribute to Ao! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/ao/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage!

Thank you so much again for all of your time invested in the project!

-->
