### PR TITLE
README: update Homebrew install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Ubuntu Linux users can directly install through [`Snapcraft`](https://snapcraft.
 
 #### Homebrew
 
-Macos users can directly install through [`Homebrew Cask`](https://caskroom.github.io/) `brew cask install ao`
+Macos users can directly install through [`Homebrew Cask`](https://caskroom.github.io/) `brew install --cask ao`
 
 #### Note
 


### PR DESCRIPTION
**Describe the bug**
`brew cask install ao` reports an error

**To Reproduce**
run `brew cask install ao` in the command line, throw an error:
`Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.`

**Expected behavior**
install successfully

**Technical Info (please complete the following information)**
 - OS: Mac OS
 - Ao Version: any

**Additional context**
Just update README `brew install --cask ao`
